### PR TITLE
#39 tests: aumento de cobertura

### DIFF
--- a/src/db/entities/equipment.ts
+++ b/src/db/entities/equipment.ts
@@ -48,7 +48,7 @@ export class Equipment {
     enum: Status
   })
   situacao: Status
-  
+
   @Column({
     type: 'enum',
     enum: Estado

--- a/tests/create-equipment-usecase.spec.ts
+++ b/tests/create-equipment-usecase.spec.ts
@@ -18,6 +18,7 @@ import {
 } from '../src/useCases/createEquipment/createEquipmentUseCase'
 import { Equipment as EquipmentDb } from '../src/db/entities/equipment'
 import { Estado } from '../src/domain/entities/equipamentEnum/estado'
+import { ScreenType } from '../src/domain/entities/equipamentEnum/screenType'
 
 describe('Test create order use case', () => {
   let equipmentRepository: MockProxy<EquipmentRepositoryProtocol>
@@ -53,13 +54,48 @@ describe('Test create order use case', () => {
     processor: 'i7'
   }
 
+  const createMonitorInterface: CreateEquipmentInterface = {
+    acquisitionDate: new Date('2023-01-20'),
+    situacao: Status.ACTIVE,
+    estado: Estado.Novo,
+    tippingNumber: 'any',
+    model: 'DELL G15',
+    serialNumber: 'any',
+    type: Type.Monitor,
+    screenType: ScreenType.LED,
+    screenSize: '40pol',
+    initialUseDate: new Date('2023-01-20').toISOString(),
+    invoiceNumber: 'any',
+    unitId: 'any_id',
+    acquisitionName: 'any_name',
+    brandName: 'brand_name',
+    ram_size: '16',
+    storageAmount: '256',
+    storageType: 'SSD',
+    processor: 'i7'
+  }
+
+  const createGeneralEquipmentInterface = {
+    acquisitionDate: new Date('2023-01-20'),
+    situacao: Status.ACTIVE,
+    estado: Estado.Novo,
+    tippingNumber: 'any',
+    model: 'DELL G15',
+    serialNumber: 'any',
+    initialUseDate: new Date('2023-01-20').toISOString(),
+    invoiceNumber: 'any',
+    unitId: 'any_id',
+    acquisitionName: 'any_name',
+    brandName: 'brand_name'
+  }
+
   const equipment: Equipment = {
     id: 'id',
     acquisition: {
       id: '',
       name: ''
     },
-    acquisitionDate: createEquipmentInterface.acquisitionDate,    
+    acquisitionDate: createEquipmentInterface.acquisitionDate,
     createdAt: new Date('2023-01-20'),
     updatedAt: new Date('2023-01-20'),
     situacao: Status.ACTIVE,
@@ -74,6 +110,30 @@ describe('Test create order use case', () => {
     storageAmount: '256',
     storageType: 'SSD' as StorageType,
     processor: 'i7',
+    unit,
+    brand: {
+      id: '',
+      name: 'brand'
+    }
+  }
+
+  const monitor: Equipment = {
+    id: 'id',
+    acquisition: {
+      id: '',
+      name: ''
+    },
+    acquisitionDate: createMonitorInterface.acquisitionDate,
+    createdAt: new Date('2023-01-20'),
+    updatedAt: new Date('2023-01-20'),
+    situacao: Status.ACTIVE,
+    estado: Estado.Novo,
+    tippingNumber: createMonitorInterface.tippingNumber,
+    model: createMonitorInterface.model,
+    serialNumber: createMonitorInterface.serialNumber,
+    type: createMonitorInterface.type as Type,
+    initialUseDate: createMonitorInterface.initialUseDate,
+    invoiceNumber: createMonitorInterface.invoiceNumber,
     unit,
     brand: {
       id: '',
@@ -165,6 +225,20 @@ describe('Test create order use case', () => {
     })
   })
 
+  test('should return NullFields if pass wrong screen type for monitor', async () => {
+    const result = await createEquipmentUseCase.execute({
+      ...createGeneralEquipmentInterface,
+      type: Type.Monitor,
+      screenSize: '40pol',
+      screenType: 'CRT'
+    })
+
+    expect(result).toEqual({
+      isSuccess: false,
+      error: new NullFields()
+    })
+  })
+
   test('should return EquipmentTypeError if pass wrong equipment type', async () => {
     const result = await createEquipmentUseCase.execute({
       ...createEquipmentInterface,
@@ -226,6 +300,44 @@ describe('Test create order use case', () => {
     expect(result).toEqual({
       isSuccess: false,
       error: new NullFields()
+    })
+  })
+
+  test('should create monitor', async () => {
+    const result = await createEquipmentUseCase.execute(createMonitorInterface)
+
+    const equipmentDB = new EquipmentDb()
+    equipmentDB.acquisition = {
+      id: '',
+      name: ''
+    }
+    equipmentDB.acquisitionDate = equipment.acquisitionDate
+    equipmentDB.unit = {
+      createdAt: new Date('2023-01-20'),
+      updatedAt: new Date('2023-01-20'),
+      id: 'teste',
+      localization: 'localization',
+      name: 'nome'
+    }
+    equipmentDB.brand = {
+      id: '',
+      name: 'brand'
+    }
+    equipmentDB.description = ''
+    equipmentDB.initialUseDate = monitor.initialUseDate
+    equipmentDB.type = monitor.type
+    equipmentDB.invoiceNumber = monitor.invoiceNumber
+    equipmentDB.model = monitor.model
+    equipmentDB.serialNumber = monitor.serialNumber
+    equipmentDB.situacao = monitor.situacao
+    equipmentDB.estado = monitor.estado
+    equipmentDB.tippingNumber = monitor.tippingNumber
+    equipmentDB.screenType = ScreenType.LED
+    equipmentDB.screenSize = '40pol'
+
+    expect(result).toEqual({
+      isSuccess: true,
+      data: equipmentDB
     })
   })
 

--- a/tests/create-equipment-usecase.spec.ts
+++ b/tests/create-equipment-usecase.spec.ts
@@ -185,6 +185,20 @@ describe('Test create order use case', () => {
     expect(unitRepository.findOne).toBeCalledTimes(1)
   })
 
+  test('should call brandRepository with no params', async () => {
+    const { brandName, ...rest } = createEquipmentInterface
+
+    await createEquipmentUseCase.execute({
+      ...rest,
+      brandName: undefined
+    })
+
+    expect(
+      brandRepository.findOneByName.mockResolvedValue(null)
+    ).toBeCalledWith(undefined)
+    expect(unitRepository.findOne).toBeCalledTimes(1)
+  })
+
   test('should return NotFoundUnit if no unit found', async () => {
     unitRepository.findOne.mockResolvedValueOnce(undefined)
 
@@ -280,8 +294,8 @@ describe('Test create order use case', () => {
   test('should return NullFields if pass required info for monitor', async () => {
     const result = await createEquipmentUseCase.execute({
       ...createEquipmentInterface,
-      type: 'Nobreak',
-      power: undefined
+      type: 'Nobreak'
+      // power: undefined
     })
 
     expect(result).toEqual({
@@ -341,12 +355,170 @@ describe('Test create order use case', () => {
     })
   })
 
+  test('should create noBreak', async () => {
+    const result = await createEquipmentUseCase.execute({
+      ...createGeneralEquipmentInterface,
+      type: Type.Nobreak,
+      power: '220'
+    })
+
+    const equipmentDB = new EquipmentDb()
+    equipmentDB.acquisition = {
+      id: '',
+      name: ''
+    }
+    equipmentDB.acquisitionDate = equipment.acquisitionDate
+    equipmentDB.unit = {
+      createdAt: new Date('2023-01-20'),
+      updatedAt: new Date('2023-01-20'),
+      id: 'teste',
+      localization: 'localization',
+      name: 'nome'
+    }
+    equipmentDB.brand = {
+      id: '',
+      name: 'brand'
+    }
+    equipmentDB.description = ''
+    equipmentDB.initialUseDate = equipment.initialUseDate
+    equipmentDB.type = Type?.Nobreak
+    equipmentDB.power = '220'
+    equipmentDB.invoiceNumber = equipment.invoiceNumber
+    equipmentDB.model = equipment.model
+    equipmentDB.serialNumber = equipment.serialNumber
+    equipmentDB.situacao = equipment.situacao
+    equipmentDB.estado = equipment.estado
+    equipmentDB.tippingNumber = equipment.tippingNumber
+
+    expect(result).toEqual({
+      isSuccess: true,
+      data: equipmentDB
+    })
+  })
+
+  test('should create estabilizador', async () => {
+    const result = await createEquipmentUseCase.execute({
+      ...createGeneralEquipmentInterface,
+      type: Type.Estabilizador,
+      power: '220'
+    })
+
+    const equipmentDB = new EquipmentDb()
+    equipmentDB.acquisition = {
+      id: '',
+      name: ''
+    }
+    equipmentDB.acquisitionDate = equipment.acquisitionDate
+    equipmentDB.unit = {
+      createdAt: new Date('2023-01-20'),
+      updatedAt: new Date('2023-01-20'),
+      id: 'teste',
+      localization: 'localization',
+      name: 'nome'
+    }
+    equipmentDB.brand = {
+      id: '',
+      name: 'brand'
+    }
+    equipmentDB.description = ''
+    equipmentDB.initialUseDate = equipment.initialUseDate
+    equipmentDB.type = Type?.Estabilizador
+    equipmentDB.power = '220'
+    equipmentDB.invoiceNumber = equipment.invoiceNumber
+    equipmentDB.model = equipment.model
+    equipmentDB.serialNumber = equipment.serialNumber
+    equipmentDB.situacao = equipment.situacao
+    equipmentDB.estado = equipment.estado
+    equipmentDB.tippingNumber = equipment.tippingNumber
+
+    expect(result).toEqual({
+      isSuccess: true,
+      data: equipmentDB
+    })
+  })
+
+  test('should create webcam', async () => {
+    const result = await createEquipmentUseCase.execute({
+      ...createGeneralEquipmentInterface,
+      type: Type.Webcam
+    })
+
+    const equipmentDB = new EquipmentDb()
+    equipmentDB.acquisition = {
+      id: '',
+      name: ''
+    }
+    equipmentDB.acquisitionDate = equipment.acquisitionDate
+    equipmentDB.unit = {
+      createdAt: new Date('2023-01-20'),
+      updatedAt: new Date('2023-01-20'),
+      id: 'teste',
+      localization: 'localization',
+      name: 'nome'
+    }
+    equipmentDB.brand = {
+      id: '',
+      name: 'brand'
+    }
+    equipmentDB.description = ''
+    equipmentDB.initialUseDate = equipment.initialUseDate
+    equipmentDB.type = Type?.Webcam
+    equipmentDB.invoiceNumber = equipment.invoiceNumber
+    equipmentDB.model = equipment.model
+    equipmentDB.serialNumber = equipment.serialNumber
+    equipmentDB.situacao = equipment.situacao
+    equipmentDB.estado = equipment.estado
+    equipmentDB.tippingNumber = equipment.tippingNumber
+
+    expect(result).toEqual({
+      isSuccess: true,
+      data: equipmentDB
+    })
+  })
+
+  test('should create webcam', async () => {
+    const result = await createEquipmentUseCase.execute({
+      ...createGeneralEquipmentInterface,
+      type: Type.Escaneador
+    })
+
+    const equipmentDB = new EquipmentDb()
+    equipmentDB.acquisition = {
+      id: '',
+      name: ''
+    }
+    equipmentDB.acquisitionDate = equipment.acquisitionDate
+    equipmentDB.unit = {
+      createdAt: new Date('2023-01-20'),
+      updatedAt: new Date('2023-01-20'),
+      id: 'teste',
+      localization: 'localization',
+      name: 'nome'
+    }
+    equipmentDB.brand = {
+      id: '',
+      name: 'brand'
+    }
+    equipmentDB.description = ''
+    equipmentDB.initialUseDate = equipment.initialUseDate
+    equipmentDB.type = Type?.Escaneador
+    equipmentDB.invoiceNumber = equipment.invoiceNumber
+    equipmentDB.model = equipment.model
+    equipmentDB.serialNumber = equipment.serialNumber
+    equipmentDB.situacao = equipment.situacao
+    equipmentDB.estado = equipment.estado
+    equipmentDB.tippingNumber = equipment.tippingNumber
+
+    expect(result).toEqual({
+      isSuccess: true,
+      data: equipmentDB
+    })
+  })
+
   test('should create equipment', async () => {
     const result = await createEquipmentUseCase.execute(
       createEquipmentInterface
     )
-
-    console.log(result.data)
 
     const equipmentDB = new EquipmentDb()
     equipmentDB.acquisition = {

--- a/tests/create-equipment-usecase.spec.ts
+++ b/tests/create-equipment-usecase.spec.ts
@@ -54,27 +54,6 @@ describe('Test create order use case', () => {
     processor: 'i7'
   }
 
-  const createMonitorInterface: CreateEquipmentInterface = {
-    acquisitionDate: new Date('2023-01-20'),
-    situacao: Status.ACTIVE,
-    estado: Estado.Novo,
-    tippingNumber: 'any',
-    model: 'DELL G15',
-    serialNumber: 'any',
-    type: Type.Monitor,
-    screenType: ScreenType.LED,
-    screenSize: '40pol',
-    initialUseDate: new Date('2023-01-20').toISOString(),
-    invoiceNumber: 'any',
-    unitId: 'any_id',
-    acquisitionName: 'any_name',
-    brandName: 'brand_name',
-    ram_size: '16',
-    storageAmount: '256',
-    storageType: 'SSD',
-    processor: 'i7'
-  }
-
   const createGeneralEquipmentInterface = {
     acquisitionDate: new Date('2023-01-20'),
     situacao: Status.ACTIVE,
@@ -110,30 +89,6 @@ describe('Test create order use case', () => {
     storageAmount: '256',
     storageType: 'SSD' as StorageType,
     processor: 'i7',
-    unit,
-    brand: {
-      id: '',
-      name: 'brand'
-    }
-  }
-
-  const monitor: Equipment = {
-    id: 'id',
-    acquisition: {
-      id: '',
-      name: ''
-    },
-    acquisitionDate: createMonitorInterface.acquisitionDate,
-    createdAt: new Date('2023-01-20'),
-    updatedAt: new Date('2023-01-20'),
-    situacao: Status.ACTIVE,
-    estado: Estado.Novo,
-    tippingNumber: createMonitorInterface.tippingNumber,
-    model: createMonitorInterface.model,
-    serialNumber: createMonitorInterface.serialNumber,
-    type: createMonitorInterface.type as Type,
-    initialUseDate: createMonitorInterface.initialUseDate,
-    invoiceNumber: createMonitorInterface.invoiceNumber,
     unit,
     brand: {
       id: '',
@@ -318,7 +273,12 @@ describe('Test create order use case', () => {
   })
 
   test('should create monitor', async () => {
-    const result = await createEquipmentUseCase.execute(createMonitorInterface)
+    const result = await createEquipmentUseCase.execute({
+      ...createGeneralEquipmentInterface,
+      type: Type.Monitor,
+      screenType: ScreenType.LED,
+      screenSize: '40pol'
+    })
 
     const equipmentDB = new EquipmentDb()
     equipmentDB.acquisition = {
@@ -338,14 +298,14 @@ describe('Test create order use case', () => {
       name: 'brand'
     }
     equipmentDB.description = ''
-    equipmentDB.initialUseDate = monitor.initialUseDate
-    equipmentDB.type = monitor.type
-    equipmentDB.invoiceNumber = monitor.invoiceNumber
-    equipmentDB.model = monitor.model
-    equipmentDB.serialNumber = monitor.serialNumber
-    equipmentDB.situacao = monitor.situacao
-    equipmentDB.estado = monitor.estado
-    equipmentDB.tippingNumber = monitor.tippingNumber
+    equipmentDB.initialUseDate = equipment.initialUseDate
+    equipmentDB.type = Type.Monitor
+    equipmentDB.invoiceNumber = equipment.invoiceNumber
+    equipmentDB.model = equipment.model
+    equipmentDB.serialNumber = equipment.serialNumber
+    equipmentDB.situacao = equipment.situacao
+    equipmentDB.estado = equipment.estado
+    equipmentDB.tippingNumber = equipment.tippingNumber
     equipmentDB.screenType = ScreenType.LED
     equipmentDB.screenSize = '40pol'
 
@@ -396,7 +356,7 @@ describe('Test create order use case', () => {
     })
   })
 
-  test('should create estabilizador', async () => {
+  test('should create "estabilizador"', async () => {
     const result = await createEquipmentUseCase.execute({
       ...createGeneralEquipmentInterface,
       type: Type.Estabilizador,
@@ -476,7 +436,7 @@ describe('Test create order use case', () => {
     })
   })
 
-  test('should create webcam', async () => {
+  test('should create "escaneador"', async () => {
     const result = await createEquipmentUseCase.execute({
       ...createGeneralEquipmentInterface,
       type: Type.Escaneador
@@ -515,7 +475,7 @@ describe('Test create order use case', () => {
     })
   })
 
-  test('should create equipment', async () => {
+  test('should create equipment (CPU)', async () => {
     const result = await createEquipmentUseCase.execute(
       createEquipmentInterface
     )

--- a/tests/errors/http.spec.ts
+++ b/tests/errors/http.spec.ts
@@ -1,0 +1,66 @@
+import {
+  ForbiddenError,
+  ServerError,
+  UnauthorizedError,
+  NotFoundError,
+  BadRequestError
+} from '../../src/presentation/errors/http'
+
+test('should create an instance of ServerError with correct message and name', () => {
+  const error = new ServerError()
+
+  expect(error).toBeInstanceOf(Error)
+  expect(error).toBeInstanceOf(ServerError)
+
+  expect(error.name).toBe('ServerError')
+  expect(error.message).toBe('Server failed. Try again soon')
+
+  expect(error.stack).toBeUndefined()
+})
+
+test('should create an instance of ServerError with correct message and name', () => {
+  const msg = new Error('Error')
+  const error = new ServerError(msg)
+
+  expect(error.stack).toBe(error.stack)
+})
+
+test('should create an instance of Unauthorized with correct name and message', () => {
+  const error = new UnauthorizedError()
+
+  expect(error).toBeInstanceOf(Error)
+  expect(error).toBeInstanceOf(UnauthorizedError)
+
+  expect(error.name).toBe('UnauthorizedError')
+  expect(error.message).toBe('Unauthorized')
+})
+
+test('should create an instance of ForbiddenError with correct name and message', () => {
+  const error = new ForbiddenError()
+
+  expect(error).toBeInstanceOf(Error)
+  expect(error).toBeInstanceOf(ForbiddenError)
+
+  expect(error.name).toBe('ForbiddenError')
+  expect(error.message).toBe('Access denied')
+})
+
+test('should create an instance of NotFoundError with correct name and message', () => {
+  const error = new NotFoundError()
+
+  expect(error).toBeInstanceOf(Error)
+  expect(error).toBeInstanceOf(NotFoundError)
+
+  expect(error.name).toBe('NotFoundError')
+  expect(error.message).toBe('Not found')
+})
+
+test('should create an instance of BadRequestError with correct name and message', () => {
+  const msg = 'Invalid Request'
+  const error = new BadRequestError(msg)
+
+  expect(error).toBeInstanceOf(Error)
+  expect(error).toBeInstanceOf(BadRequestError)
+
+  expect(error.name).toBe('ForbiddenError')
+})

--- a/tests/errors/validation.spec.ts
+++ b/tests/errors/validation.spec.ts
@@ -1,0 +1,22 @@
+import { RequiredFieldError } from '../../src/presentation/errors/validation'
+
+test('should create an instance of RequiredFieldError with correct message and name', () => {
+  const error = new RequiredFieldError()
+
+  expect(error).toBeInstanceOf(Error)
+  expect(error).toBeInstanceOf(RequiredFieldError)
+
+  expect(error.name).toBe('RequiredFieldError')
+  expect(error.message).toBe('Field required')
+})
+
+test('should create an instance of RequiredFieldError with correct message and name', () => {
+  const fieldName = 'field_name'
+  const error = new RequiredFieldError(fieldName)
+
+  expect(error).toBeInstanceOf(Error)
+  expect(error).toBeInstanceOf(RequiredFieldError)
+
+  expect(error.name).toBe('RequiredFieldError')
+  expect(error.message).toBe(`The field ${fieldName} is required`)
+})

--- a/tests/findMovementsUseCase.spec.ts
+++ b/tests/findMovementsUseCase.spec.ts
@@ -2,7 +2,11 @@ import { MockProxy, mock } from 'jest-mock-extended'
 
 import { MovementRepositoryProtocol } from '../src/repository/protocol/movementRepositoryProtocol'
 
-import { FindMovementsUseCase, FindMovementsUseCaseData, InvalidDateError } from '../src/useCases/findMovements/findMovementsUseCase'
+import {
+  FindMovementsUseCase,
+  FindMovementsUseCaseData,
+  InvalidDateError
+} from '../src/useCases/findMovements/findMovementsUseCase'
 
 import { Equipment } from '../src/domain/entities/equipment'
 import { Type } from '../src/domain/entities/equipamentEnum/type'
@@ -11,225 +15,237 @@ import { Estado } from '../src/domain/entities/equipamentEnum/estado'
 import { Movement } from '../src/domain/entities/movement'
 
 describe('Find movements use case', () => {
-    let movementRepository : MockProxy<MovementRepositoryProtocol>
+  let movementRepository: MockProxy<MovementRepositoryProtocol>
 
-    let findMovementsUseCase : FindMovementsUseCase
+  let findMovementsUseCase: FindMovementsUseCase
 
-    let mockedEquipment : Equipment
+  let mockedEquipment: Equipment
 
-    beforeEach(() => {
-        mockedEquipment = {
-            id: "c266c9d5-4e91-4c2e-9c38-fb8710d7e896",
-            tippingNumber: "123123",
-            serialNumber: "123",
-            type: Type.Nobreak,
-            situacao: Status.ACTIVE,
-            estado: Estado.Novo,
-            model: "Xiaomi XT",
-            description: "",
-            initialUseDate: "2022-12-12",
-            acquisitionDate: new Date("2022-12-12"),
-            invoiceNumber: "123",
-            power: "220",
-            createdAt: new Date("2023-01-09T21:31:56.015Z"),
-            updatedAt: new Date("2023-01-09T21:49:26.057Z")
-        }
+  beforeEach(() => {
+    mockedEquipment = {
+      id: 'c266c9d5-4e91-4c2e-9c38-fb8710d7e896',
+      tippingNumber: '123123',
+      serialNumber: '123',
+      type: Type.Nobreak,
+      situacao: Status.ACTIVE,
+      estado: Estado.Novo,
+      model: 'Xiaomi XT',
+      description: '',
+      initialUseDate: '2022-12-12',
+      acquisitionDate: new Date('2022-12-12'),
+      invoiceNumber: '123',
+      power: '220',
+      createdAt: new Date('2023-01-09T21:31:56.015Z'),
+      updatedAt: new Date('2023-01-09T21:49:26.057Z')
+    }
 
-        movementRepository = mock()
+    movementRepository = mock()
 
-        findMovementsUseCase = new FindMovementsUseCase(movementRepository)
-    })
+    findMovementsUseCase = new FindMovementsUseCase(movementRepository)
+  })
 
-    test('should find movements with a simple query', async() => {
-        const mockedResult : Movement[] = [
-            {
-                id: "130265af-6afd-494d-b025-e657db264e56",
-                date: new Date("2023-01-09T21:36:35.971Z"),
-                userId: "941f7db3-b754-4811-9884-24874fc40e28",
-                type: 1,
-                description: "broke it lmao",
-                equipments: [mockedEquipment],
-                destination: null,
-                inChargeName: 'José Matheus',
-                inChargeRole: 'Sargento',
-                chiefName: 'Matheus Texeira',
-                chiefRole: 'Delegado'
-            },
-            {
-                id: "8253fbbd-eb19-42a6-86e6-f45126921e37",
-                date: new Date("2023-01-09T21:39:25.373Z"),
-                userId: "941f7db3-b754-4811-9884-24874fc40e28",
-                type: 1,
-                description: "broke it lmao",
-                equipments: [mockedEquipment],
-                destination: null,
-                inChargeName: 'José Matheus',
-                inChargeRole: 'Sargento',
-                chiefName: 'Matheus Texeira',
-                chiefRole: 'Delegado'
-            }
-        ]
+  test('should find movements with a simple query', async () => {
+    const mockedResult: Movement[] = [
+      {
+        id: '130265af-6afd-494d-b025-e657db264e56',
+        date: new Date('2023-01-09T21:36:35.971Z'),
+        userId: '941f7db3-b754-4811-9884-24874fc40e28',
+        type: 1,
+        description: 'broke it lmao',
+        equipments: [mockedEquipment],
+        destination: null,
+        inChargeName: 'José Matheus',
+        inChargeRole: 'Sargento',
+        chiefName: 'Matheus Texeira',
+        chiefRole: 'Delegado'
+      },
+      {
+        id: '8253fbbd-eb19-42a6-86e6-f45126921e37',
+        date: new Date('2023-01-09T21:39:25.373Z'),
+        userId: '941f7db3-b754-4811-9884-24874fc40e28',
+        type: 1,
+        description: 'broke it lmao',
+        equipments: [mockedEquipment],
+        destination: null,
+        inChargeName: 'José Matheus',
+        inChargeRole: 'Sargento',
+        chiefName: 'Matheus Texeira',
+        chiefRole: 'Delegado'
+      }
+    ]
 
-        const query : FindMovementsUseCaseData  = {
-            type: 1
-        }
+    const query: FindMovementsUseCaseData = {
+      type: 1
+    }
 
-        movementRepository.genericFind.mockResolvedValueOnce(mockedResult)
+    movementRepository.genericFind.mockResolvedValueOnce(mockedResult)
 
-        const result = await findMovementsUseCase.execute(query)
+    const result = await findMovementsUseCase.execute(query)
 
-        expect(result).toHaveProperty('isSuccess', true)
-        expect(result).toHaveProperty('data')
-        expect(result.data).toBeInstanceOf(Array)
-        expect(result.data).toHaveLength(2)
-        expect(result.data[0]).toHaveProperty('type', 1)
-        expect(result.data[1]).toHaveProperty('type', 1)
-    })
+    expect(result).toHaveProperty('isSuccess', true)
+    expect(result).toHaveProperty('data')
+    expect(result.data).toBeInstanceOf(Array)
+    expect(result.data).toHaveLength(2)
+    expect(result.data[0]).toHaveProperty('type', 1)
+    expect(result.data[1]).toHaveProperty('type', 1)
+  })
 
-    test('should find movements with a complex query', async() => {
-        const mockedResult : Movement[] = [
-            {
-                id: "130265af-6afd-494d-b025-e657db264e56",
-                date: new Date("2023-01-09T21:36:35.971Z"),
-                userId: "941f7db3-b754-4811-9884-24874fc40e28",
-                type: 1,
-                description: "broke it lmao",
-                equipments: [mockedEquipment],
-                destination: null,
-                inChargeName: 'José Matheus',
-                inChargeRole: 'Sargento',
-                chiefName: 'Matheus Texeira',
-                chiefRole: 'Delegado'
-            },
-            {
-                id: "8253fbbd-eb19-42a6-86e6-f45126921e37",
-                date: new Date("2023-01-09T21:39:25.373Z"),
-                userId: "941f7db3-b754-4811-9884-24874fc40e28",
-                type: 1,
-                description: "broke it lmao",
-                equipments: [mockedEquipment],
-                destination: null,
-                inChargeName: 'José Matheus',
-                inChargeRole: 'Sargento',
-                chiefName: 'Matheus Texeira',
-                chiefRole: 'Delegado'
-            }
-        ]
+  test('should find movements with a complex query', async () => {
+    const mockedResult: Movement[] = [
+      {
+        id: '130265af-6afd-494d-b025-e657db264e56',
+        date: new Date('2023-01-09T21:36:35.971Z'),
+        userId: '941f7db3-b754-4811-9884-24874fc40e28',
+        type: 1,
+        description: 'broke it lmao',
+        equipments: [mockedEquipment],
+        destination: null,
+        inChargeName: 'José Matheus',
+        inChargeRole: 'Sargento',
+        chiefName: 'Matheus Texeira',
+        chiefRole: 'Delegado'
+      },
+      {
+        id: '8253fbbd-eb19-42a6-86e6-f45126921e37',
+        date: new Date('2023-01-09T21:39:25.373Z'),
+        userId: '941f7db3-b754-4811-9884-24874fc40e28',
+        type: 1,
+        description: 'broke it lmao',
+        equipments: [mockedEquipment],
+        destination: null,
+        inChargeName: 'José Matheus',
+        inChargeRole: 'Sargento',
+        chiefName: 'Matheus Texeira',
+        chiefRole: 'Delegado'
+      }
+    ]
 
-        const query : FindMovementsUseCaseData = {
-            type: 1,
-            userid: '941f7db3-b754-4811-9884-24874fc40e28',
-            equipmentid: 'c266c9d5-4e91-4c2e-9c38-fb8710d7e896'
-        }
+    const query: FindMovementsUseCaseData = {
+      type: 1,
+      userid: '941f7db3-b754-4811-9884-24874fc40e28',
+      equipmentid: 'c266c9d5-4e91-4c2e-9c38-fb8710d7e896'
+    }
 
-        movementRepository.genericFind.mockResolvedValueOnce(mockedResult)
+    movementRepository.genericFind.mockResolvedValueOnce(mockedResult)
 
-        const result = await findMovementsUseCase.execute(query)
+    const result = await findMovementsUseCase.execute(query)
 
-        expect(result).toHaveProperty('isSuccess', true)
-        expect(result).toHaveProperty('data')
-        expect(result.data).toBeInstanceOf(Array)
-        expect(result.data).toHaveLength(2)
-        expect(result.data[0]).toHaveProperty('type', 1)
-        expect(result.data[1]).toHaveProperty('type', 1)
-        expect(result.data[0]).toHaveProperty('userId', '941f7db3-b754-4811-9884-24874fc40e28')
-        expect(result.data[1]).toHaveProperty('userId', '941f7db3-b754-4811-9884-24874fc40e28')
-        expect(result.data[0]).toHaveProperty('equipments')
-        expect(result.data[0].equipments).toHaveLength(1)
-        expect(result.data[0].equipments[0]).toHaveProperty('id', 'c266c9d5-4e91-4c2e-9c38-fb8710d7e896')
-        expect(result.data[1]).toHaveProperty('equipments')
-        expect(result.data[1].equipments).toHaveLength(1)
-        expect(result.data[1].equipments[0]).toHaveProperty('id', 'c266c9d5-4e91-4c2e-9c38-fb8710d7e896')
-    })
+    expect(result).toHaveProperty('isSuccess', true)
+    expect(result).toHaveProperty('data')
+    expect(result.data).toBeInstanceOf(Array)
+    expect(result.data).toHaveLength(2)
+    expect(result.data[0]).toHaveProperty('type', 1)
+    expect(result.data[1]).toHaveProperty('type', 1)
+    expect(result.data[0]).toHaveProperty(
+      'userId',
+      '941f7db3-b754-4811-9884-24874fc40e28'
+    )
+    expect(result.data[1]).toHaveProperty(
+      'userId',
+      '941f7db3-b754-4811-9884-24874fc40e28'
+    )
+    expect(result.data[0]).toHaveProperty('equipments')
+    expect(result.data[0].equipments).toHaveLength(1)
+    expect(result.data[0].equipments[0]).toHaveProperty(
+      'id',
+      'c266c9d5-4e91-4c2e-9c38-fb8710d7e896'
+    )
+    expect(result.data[1]).toHaveProperty('equipments')
+    expect(result.data[1].equipments).toHaveLength(1)
+    expect(result.data[1].equipments[0]).toHaveProperty(
+      'id',
+      'c266c9d5-4e91-4c2e-9c38-fb8710d7e896'
+    )
+  })
 
-    test('should not find movements with invalid date ranges', async() => {
-        const mockedResult : Movement[] = [
-            {
-                id: "130265af-6afd-494d-b025-e657db264e56",
-                date: new Date("2023-01-09T21:36:35.971Z"),
-                userId: "941f7db3-b754-4811-9884-24874fc40e28",
-                type: 1,
-                description: "broke it lmao",
-                equipments: [mockedEquipment],
-                destination: null,
-                inChargeName: 'José Matheus',
-                inChargeRole: 'Sargento',
-                chiefName: 'Matheus Texeira',
-                chiefRole: 'Delegado'
-            },
-            {
-                id: "8253fbbd-eb19-42a6-86e6-f45126921e37",
-                date: new Date("2023-01-09T21:39:25.373Z"),
-                userId: "941f7db3-b754-4811-9884-24874fc40e28",
-                type: 1,
-                description: "broke it lmao",
-                equipments: [mockedEquipment],
-                destination: null,
-                inChargeName: 'José Matheus',
-                inChargeRole: 'Sargento',
-                chiefName: 'Matheus Texeira',
-                chiefRole: 'Delegado'
-            }
-        ]
+  test('should not find movements with invalid date ranges', async () => {
+    const mockedResult: Movement[] = [
+      {
+        id: '130265af-6afd-494d-b025-e657db264e56',
+        date: new Date('2023-01-09T21:36:35.971Z'),
+        userId: '941f7db3-b754-4811-9884-24874fc40e28',
+        type: 1,
+        description: 'broke it lmao',
+        equipments: [mockedEquipment],
+        destination: null,
+        inChargeName: 'José Matheus',
+        inChargeRole: 'Sargento',
+        chiefName: 'Matheus Texeira',
+        chiefRole: 'Delegado'
+      },
+      {
+        id: '8253fbbd-eb19-42a6-86e6-f45126921e37',
+        date: new Date('2023-01-09T21:39:25.373Z'),
+        userId: '941f7db3-b754-4811-9884-24874fc40e28',
+        type: 1,
+        description: 'broke it lmao',
+        equipments: [mockedEquipment],
+        destination: null,
+        inChargeName: 'José Matheus',
+        inChargeRole: 'Sargento',
+        chiefName: 'Matheus Texeira',
+        chiefRole: 'Delegado'
+      }
+    ]
 
-        const query : FindMovementsUseCaseData  = {
-            type: 1,
-            lowerdate: new Date('2023-01-10T07:16:32.276Z'),
-            higherdate: new Date('2023-01-10T07:14:54.078Z')
-        }
+    const query: FindMovementsUseCaseData = {
+      type: 1,
+      lowerdate: new Date('2023-01-10T07:16:32.276Z'),
+      higherdate: new Date('2023-01-10T07:14:54.078Z')
+    }
 
-        movementRepository.genericFind.mockResolvedValueOnce(mockedResult)
+    movementRepository.genericFind.mockResolvedValueOnce(mockedResult)
 
-        const result = await findMovementsUseCase.execute(query)
+    const result = await findMovementsUseCase.execute(query)
 
-        expect(result).toHaveProperty('isSuccess', false)
-        expect(result).not.toHaveProperty('data')
-        expect(result).toHaveProperty('error')
-        expect(result.error).toBeInstanceOf(InvalidDateError)
-    })
+    expect(result).toHaveProperty('isSuccess', false)
+    expect(result).not.toHaveProperty('data')
+    expect(result).toHaveProperty('error')
+    expect(result.error).toBeInstanceOf(InvalidDateError)
+  })
 
-    test('should not find movements with by date when higher date is missing', async() => {
-        const mockedResult : Movement[] = [
-            {
-                id: "130265af-6afd-494d-b025-e657db264e56",
-                date: new Date("2023-01-09T21:36:35.971Z"),
-                userId: "941f7db3-b754-4811-9884-24874fc40e28",
-                type: 1,
-                description: "broke it lmao",
-                equipments: [mockedEquipment],
-                destination: null,
-                inChargeName: 'José Matheus',
-                inChargeRole: 'Sargento',
-                chiefName: 'Matheus Texeira',
-                chiefRole: 'Delegado'
-            },
-            {
-                id: "8253fbbd-eb19-42a6-86e6-f45126921e37",
-                date: new Date("2023-01-09T21:39:25.373Z"),
-                userId: "941f7db3-b754-4811-9884-24874fc40e28",
-                type: 1,
-                description: "broke it lmao",
-                equipments: [mockedEquipment],
-                destination: null,
-                inChargeName: 'José Matheus',
-                inChargeRole: 'Sargento',
-                chiefName: 'Matheus Texeira',
-                chiefRole: 'Delegado'
-            }
-        ]
+  test('should not find movements with by date when higher date is missing', async () => {
+    const mockedResult: Movement[] = [
+      {
+        id: '130265af-6afd-494d-b025-e657db264e56',
+        date: new Date('2023-01-09T21:36:35.971Z'),
+        userId: '941f7db3-b754-4811-9884-24874fc40e28',
+        type: 1,
+        description: 'broke it lmao',
+        equipments: [mockedEquipment],
+        destination: null,
+        inChargeName: 'José Matheus',
+        inChargeRole: 'Sargento',
+        chiefName: 'Matheus Texeira',
+        chiefRole: 'Delegado'
+      },
+      {
+        id: '8253fbbd-eb19-42a6-86e6-f45126921e37',
+        date: new Date('2023-01-09T21:39:25.373Z'),
+        userId: '941f7db3-b754-4811-9884-24874fc40e28',
+        type: 1,
+        description: 'broke it lmao',
+        equipments: [mockedEquipment],
+        destination: null,
+        inChargeName: 'José Matheus',
+        inChargeRole: 'Sargento',
+        chiefName: 'Matheus Texeira',
+        chiefRole: 'Delegado'
+      }
+    ]
 
-        const query : FindMovementsUseCaseData  = {
-            type: 1,
-            lowerdate: new Date('2023-01-10T07:16:32.276Z')
-        }
+    const query: FindMovementsUseCaseData = {
+      type: 1,
+      lowerdate: new Date('2023-01-10T07:16:32.276Z')
+    }
 
-        movementRepository.genericFind.mockResolvedValueOnce(mockedResult)
+    movementRepository.genericFind.mockResolvedValueOnce(mockedResult)
 
-        const result = await findMovementsUseCase.execute(query)
+    const result = await findMovementsUseCase.execute(query)
 
-        expect(result).toHaveProperty('isSuccess', false)
-        expect(result).not.toHaveProperty('data')
-        expect(result).toHaveProperty('error')
-        expect(result.error).toBeInstanceOf(InvalidDateError)
-    })
+    expect(result).toHaveProperty('isSuccess', false)
+    expect(result).not.toHaveProperty('data')
+    expect(result).toHaveProperty('error')
+    expect(result.error).toBeInstanceOf(InvalidDateError)
+  })
 })

--- a/tests/update-order-service-controller.spec.ts
+++ b/tests/update-order-service-controller.spec.ts
@@ -1,90 +1,41 @@
 import { mock } from 'jest-mock-extended'
-import { Estado } from '../src/domain/entities/equipamentEnum/estado'
-import { Status } from '../src/domain/entities/equipamentEnum/status'
-import { Status as OSStatus } from '../src/domain/entities/serviceOrderEnum/status'
-import { Type } from '../src/domain/entities/equipamentEnum/type'
-import { Equipment } from '../src/domain/entities/equipment'
-import { OrderService } from '../src/domain/entities/order-service'
 import {
   UpdateOrderServiceController,
   UpdateOrderServiceHttpRequest
 } from '../src/presentation/controller/update-order-service-controller'
+import { ok, notFound, badRequest } from '../src/presentation/helpers'
 import {
-  ok,
-  notFound,
-  badRequest,
-  serverError
-} from '../src/presentation/helpers'
-import { 
-    UpdateOrderServiceUseCaseData,
-    UpdateOrderServiceUseCase } from '../src/useCases/update-order-service/update-order-service' 
+  UpdateOrderServiceUseCaseData,
+  UpdateOrderServiceUseCase
+} from '../src/useCases/update-order-service/update-order-service'
 import {
   EquipmentNotFoundError,
   InvalidAuthorError,
   InvalidSenderError,
-  InvalidDateError,
-  UpdateOrderServiceError
+  InvalidDateError
 } from '../src/useCases/create-order-service/errors'
 
 const updateOrderServiceUseCaseMocked = mock<UpdateOrderServiceUseCase>()
 const updateOrderServiceController = new UpdateOrderServiceController(
-    updateOrderServiceUseCaseMocked
+  updateOrderServiceUseCaseMocked
 )
-
-const equipment: Equipment = {
-  id: 'id',
-  acquisitionDate: new Date(),
-  createdAt: new Date(),
-  updatedAt: new Date(),
-  situacao: Status.ACTIVE,
-  tippingNumber: 'any',
-  model: 'DELL G15',
-  serialNumber: 'any',
-  type: Type.CPU,
-  initialUseDate: new Date().toISOString(),
-  invoiceNumber: 'any',
-  estado: Estado.Novo
-}
-
-const orderService: OrderService = {
-  receiverName: '',
-  createdAt: new Date(),
-  updatedAt: new Date(),
-  date: new Date(),
-  id: 'any_id',
-  receiverFunctionalNumber: 'any',
-  status: ('MAINTENANCE' as OSStatus),
-  equipment,
-  authorId: 'any_author',
-  equipmentSnapshot: equipment,
-  sender: 'any_sender',
-  senderFunctionalNumber: 'any_sender_number',
-  history: {
-    equipment,
-    equipmentSnapshot: {},
-    createdAt: new Date(),
-    id: 'any_id',
-    updatedAt: new Date()
-  }
-}
-
 const request: UpdateOrderServiceHttpRequest = {
-    id: 'any_id', 
-    status: 'CANCELED', 
-    techinicias: [], 
-    recieverDate: new Date().toISOString(),
-    authorFunctionalNumber: 'any',
-    date: new Date().toISOString(),
-    description: '',
-    equipmentId: '',
-    receiverName: '',
-    senderFunctionalNumber: '',
-    senderName: '',
-    userId: '',
-    recieverFunctionalNumber: ''
+  id: 'any_id',
+  status: 'CANCELED',
+  techinicias: [],
+  recieverDate: new Date().toISOString(),
+  authorFunctionalNumber: 'any',
+  date: new Date().toISOString(),
+  description: '',
+  equipmentId: '',
+  receiverName: '',
+  senderFunctionalNumber: '',
+  senderName: '',
+  userId: '',
+  recieverFunctionalNumber: ''
 }
 
-const useCaseParam : UpdateOrderServiceUseCaseData = {
+const useCaseParam: UpdateOrderServiceUseCaseData = {
   equipmentId: request.equipmentId,
   authorId: request.userId,
   authorFunctionalNumber: request.authorFunctionalNumber,
@@ -94,8 +45,8 @@ const useCaseParam : UpdateOrderServiceUseCaseData = {
   description: request.description,
   receiverName: request.receiverName,
   reciverFunctionalNumber: request.recieverFunctionalNumber,
-  id: request.id, 
-  status: request.status, 
+  id: request.id,
+  status: request.status,
   techinicias: request.techinicias,
   receiverDate: request.recieverDate
 }
@@ -103,7 +54,7 @@ const useCaseParam : UpdateOrderServiceUseCaseData = {
 describe('Should test UpdateOrderServiceController', () => {
   it('should update order service with success', async () => {
     updateOrderServiceUseCaseMocked.execute.mockResolvedValue({
-      isSuccess: true,
+      isSuccess: true
     })
 
     const response = await updateOrderServiceController.perform(request)


### PR DESCRIPTION
## Modificações
Aumento na cobertura de testes
## Descrição
Foram escritos testes para cadastro de equipamentos dos tipos monitor, escaneador, webcam, no break e estabilizador. Além disso foram criados testes para os erros de http.
## _Issue_ relacionado
 #39 - Teste no backend de equipamento
## Lista de controle:
- [ ] Subir a cobertura para mais de 95% dos statements
- [ ] Meu _commits_ segue a política de commits do repo.
- [ ] Todos os testes foram aprovados.