### PR TITLE
45 validacao 10 minutos

### DIFF
--- a/src/factories/controllers/deleteEquipment.ts
+++ b/src/factories/controllers/deleteEquipment.ts
@@ -1,0 +1,6 @@
+import { DeleteEquipmentController } from '../../presentation/controller/deleteEquipmentController'
+import { makeDeleteEquipment } from '../useCases/deleteEquipment'
+
+export const makeDeleteEquipmentController = () => {
+    return new DeleteEquipmentController(makeDeleteEquipment())
+}

--- a/src/factories/useCases/deleteEquipment.ts
+++ b/src/factories/useCases/deleteEquipment.ts
@@ -1,0 +1,9 @@
+import { EquipmentRepository } from '../../repository/equipamentRepository'
+
+import { DeleteEquipmentUseCase } from '../../useCases/deleteEquipment/deleteEquipmentUseCase'
+
+export const makeDeleteEquipment = () => {
+    const equipmentRepository = new EquipmentRepository()
+
+    return new DeleteEquipmentUseCase(equipmentRepository)
+}

--- a/src/presentation/controller/deleteEquipmentController.ts
+++ b/src/presentation/controller/deleteEquipmentController.ts
@@ -1,0 +1,44 @@
+import {
+    DeleteEquipmentUseCase,
+    DeleteEquipmentUseCaseData,
+    InvalidEquipmentError,
+    NullFieldsError,
+    TimeLimitError
+  } from '../../useCases/deleteEquipment/deleteEquipmentUseCase'
+  
+  import { Controller } from '../protocols/controller'
+  import {
+    badRequest,
+    HttpResponse,
+    ok,
+    serverError,
+    notFound,
+    unauthorized
+  } from '../helpers'
+  
+  type Result = {
+    result: boolean
+  }
+  
+  type Model = Error | Result
+  
+  export class DeleteEquipmentController extends Controller {
+    constructor(private readonly deleteEquipment: DeleteEquipmentUseCase) {
+      super()
+    }
+  
+    async perform(
+      httpRequest: DeleteEquipmentUseCaseData
+    ): Promise<HttpResponse<Model>> {
+      const response = await this.deleteEquipment.execute(httpRequest)
+  
+      if (response.isSuccess) return ok({ result: true })
+      if (response.error instanceof NullFieldsError)
+        return badRequest(response.error)
+      if (response.error instanceof InvalidEquipmentError)
+        return notFound(response.error)
+      if (response.error instanceof TimeLimitError) return unauthorized()
+      return serverError(response.error)
+    }
+  }
+  

--- a/src/repository/equipamentRepository.ts
+++ b/src/repository/equipamentRepository.ts
@@ -59,4 +59,16 @@ export class EquipmentRepository implements EquipmentRepositoryProtocol {
     })
     return result
   }
+  async deleteOne(id: string): Promise<boolean> {
+    const equipament: Equipment[] = await this.genericFind({
+      id,
+      page: 0,
+      resultQuantity: 1
+    })
+
+    const result = await this.equipmentRepository.delete(id)
+
+    if (result.affected === 1) return true
+    return false
+  }
 }

--- a/src/repository/protocol/equipmentRepositoryProtocol.ts
+++ b/src/repository/protocol/equipmentRepositoryProtocol.ts
@@ -7,4 +7,5 @@ export interface EquipmentRepositoryProtocol {
   genericFind(query: any): Promise<Equipment[]>
   findByTippingNumberOrSerialNumber(id: string): Promise<Equipment | null>
   findByTippingNumber(tippingNumber: string): Promise<Equipment | null>
+  deleteOne(id: string): Promise<boolean>
 }

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -3,6 +3,7 @@ import { Router } from 'express'
 import { adaptExpressRoute as adapt } from './adapters/express-router'
 import { makeCreateOrderController } from './factories/controllers/create-order-service'
 import { makeCreateEquipmentController } from './factories/controllers/createEquipment'
+import { makeDeleteEquipmentController } from './factories/controllers/deleteEquipment'
 import { makeFindAllAcquisitionsController } from './factories/controllers/findAllAcquisitions'
 import { makeFindAllBrandsController } from './factories/controllers/findAllBrands'
 import { makeFindAllUnitsController } from './factories/controllers/findAllUnits'
@@ -23,6 +24,7 @@ routes.post(
 )
 routes.get('/find', adapt(makeGetEquipmentController()))
 routes.post('/createEquipment', adapt(makeCreateEquipmentController()))
+routes.delete('/deleteEquipment', adapt(makeDeleteEquipmentController()))
 routes.get('/getAllUnits', adapt(makeFindAllUnitsController()))
 routes.get('/getAllBrands', adapt(makeFindAllBrandsController()))
 routes.get('/getAllAcquisitions', adapt(makeFindAllAcquisitionsController()))

--- a/src/useCases/deleteEquipment/deleteEquipmentUseCase.ts
+++ b/src/useCases/deleteEquipment/deleteEquipmentUseCase.ts
@@ -1,0 +1,89 @@
+import { Equipment } from '../../db/entities/equipment'
+
+import { UseCase, UseCaseReponse } from '../protocol/useCase'
+
+import { EquipmentRepositoryProtocol } from '../../repository/protocol/equipmentRepositoryProtocol'
+
+export type DeleteEquipmentUseCaseData = {
+  id: string
+}
+
+export class NullFieldsError extends Error {
+  constructor() {
+    super('Um ou mais campos obrigatórios possuem valores nulos.')
+    this.name = 'NullFieldsError'
+  }
+}
+
+export class InvalidEquipmentError extends Error {
+  constructor() {
+    super('ID fornecido inválido.')
+    this.name = 'InvalidEquipmentError'
+  }
+}
+
+export class TimeLimitError extends Error {
+  constructor() {
+    super('Tempo limite para operação excedido.')
+    this.name = 'TimeLimitError'
+  }''
+}
+
+
+export class DeleteEquipmentUseCase
+  implements UseCase<DeleteEquipmentUseCaseData, boolean>
+{
+  constructor(
+    private readonly equipmentRepository: EquipmentRepositoryProtocol
+  ) {}
+
+  private areFieldsNull(data: DeleteEquipmentUseCaseData): boolean {
+    return data.id === ''
+  }
+
+  async execute(
+    data: DeleteEquipmentUseCaseData
+  ): Promise<UseCaseReponse<undefined>> {
+    if (this.areFieldsNull(data))
+      return {
+        isSuccess: false,
+        error: new NullFieldsError()
+      }
+
+    const timeLimit = 60 * 10 * 1000// 10 minutes
+
+    const result: Equipment[] = await this.equipmentRepository.genericFind({
+      id: data.id,
+      page: 0,
+      resultQuantity: 1
+    })
+
+    if (result.length < 1)
+      return {
+        isSuccess: false,
+        error: new InvalidEquipmentError()
+      }
+
+    const equipment: Equipment = result[0]
+
+    const now = new Date()
+
+    if ((now as any) - (equipment.createdAt as any) > timeLimit)
+      return {
+        isSuccess: false,
+        error: new TimeLimitError()
+      }
+
+    const wasDeleteSuccessful = await this.equipmentRepository.deleteOne(data.id)
+
+    if (!wasDeleteSuccessful)
+      return {
+        isSuccess: false,
+        error: new Error()
+      }
+
+    return {
+      isSuccess: true
+    }
+  }
+}

--- a/tests/deleteEquipmentController.spec.ts
+++ b/tests/deleteEquipmentController.spec.ts
@@ -1,0 +1,107 @@
+import { MockProxy, mock } from 'jest-mock-extended'
+
+import { NullFields } from '../src/useCases/createEquipment/createEquipmentUseCase'
+import { DeleteEquipmentController } from '../src/presentation/controller/deleteEquipmentController'
+
+import { HttpResponse } from '../src/presentation/helpers/http'
+import { ServerError, UnauthorizedError } from '../src/presentation/errors'
+import {
+  DeleteEquipmentUseCase,
+  DeleteEquipmentUseCaseData,
+  InvalidEquipmentError,
+  TimeLimitError
+} from '../src/useCases/deleteEquipment/deleteEquipmentUseCase'
+
+describe('Delete equipment controller', () => {
+  let deleteEquipmentUseCase: MockProxy<DeleteEquipmentUseCase>
+  let deleteEquipmentController: DeleteEquipmentController
+
+  beforeEach(() => {
+    deleteEquipmentUseCase = mock()
+    deleteEquipmentController = new DeleteEquipmentController(
+      deleteEquipmentUseCase
+    )
+  })
+
+  test('should get a successful response', async () => {
+    const data: DeleteEquipmentUseCaseData = {
+      id: '130265af-6afd-494d-b025-e657db264e56'
+    }
+
+    deleteEquipmentUseCase.execute.mockResolvedValue({
+      isSuccess: true
+    })
+
+    const response: HttpResponse = await deleteEquipmentController.perform(data)
+
+    expect(response).toHaveProperty('statusCode', 200)
+  })
+
+  test('should get a bad request response', async () => {
+    const data: DeleteEquipmentUseCaseData = {
+      id: '130265af-6afd-494d-b025-e657db264e56'
+    }
+
+    deleteEquipmentUseCase.execute.mockResolvedValue({
+      isSuccess: false,
+      error: new NullFields()
+    })
+
+    const response: HttpResponse = await deleteEquipmentController.perform(data)
+
+    expect(response).toHaveProperty('statusCode', 500)
+    expect(response).toHaveProperty('data')
+    expect(response.data).toBeInstanceOf(NullFields)
+  })
+
+  test('should get a invalid moviment error response', async () => {
+    const data: DeleteEquipmentUseCaseData = {
+      id: '130265af-6afd-494d-b025-e657db264e56'
+    }
+
+    deleteEquipmentUseCase.execute.mockResolvedValue({
+      isSuccess: false,
+      error: new InvalidEquipmentError()
+    })
+
+    const response: HttpResponse = await deleteEquipmentController.perform(data)
+
+    expect(response).toHaveProperty('statusCode', 404)
+    expect(response).toHaveProperty('data')
+    expect(response.data).toBeInstanceOf(InvalidEquipmentError)
+  })
+
+  test('should get a time limit error response', async () => {
+    const data: DeleteEquipmentUseCaseData = {
+      id: '130265af-6afd-494d-b025-e657db264e56'
+    }
+
+    deleteEquipmentUseCase.execute.mockResolvedValue({
+      isSuccess: false,
+      error: new TimeLimitError()
+    })
+
+    const response: HttpResponse = await deleteEquipmentController.perform(data)
+
+    expect(response).toHaveProperty('statusCode', 401)
+    expect(response).toHaveProperty('data')
+    expect(response.data).toBeInstanceOf(UnauthorizedError)
+  })
+
+  test('should return server error response', async () => {
+    const data: DeleteEquipmentUseCaseData = {
+      id: '130265af-6afd-494d-b025-e657db264e56'
+    }
+
+    deleteEquipmentUseCase.execute.mockResolvedValue({
+      isSuccess: false,
+      error: new ServerError()
+    })
+
+    const response: HttpResponse = await deleteEquipmentController.perform(data)
+
+    expect(response).toHaveProperty('statusCode', 500)
+    expect(response).toHaveProperty('data')
+    expect(response.data).toBeInstanceOf(ServerError)
+  })
+})

--- a/tests/deleteEquipmentUseCase.spec.ts
+++ b/tests/deleteEquipmentUseCase.spec.ts
@@ -1,6 +1,5 @@
 import { MockProxy, mock } from 'jest-mock-extended'
 
-import { Equipment } from '../src/domain/entities/equipment'
 import { Status } from '../src/domain/entities/equipamentEnum/status'
 import { Estado } from '../src/domain/entities/equipamentEnum/estado'
 import { Type } from '../src/domain/entities/equipamentEnum/type'

--- a/tests/deleteEquipmentUseCase.spec.ts
+++ b/tests/deleteEquipmentUseCase.spec.ts
@@ -1,0 +1,105 @@
+import { MockProxy, mock } from 'jest-mock-extended'
+
+import { Equipment } from '../src/domain/entities/equipment'
+import { Status } from '../src/domain/entities/equipamentEnum/status'
+import { Estado } from '../src/domain/entities/equipamentEnum/estado'
+import { Type } from '../src/domain/entities/equipamentEnum/type'
+
+import { Equipment as EquipmentDb } from '../src/db/entities/equipment'
+
+import { EquipmentRepositoryProtocol } from '../src/repository/protocol/equipmentRepositoryProtocol'
+
+import {
+  DeleteEquipmentUseCase,
+  DeleteEquipmentUseCaseData,
+  InvalidEquipmentError,
+  TimeLimitError,
+  NullFieldsError
+} from '../src/useCases/deleteEquipment/deleteEquipmentUseCase'
+
+describe('Find equipments use case', () => {
+  let equipmentRepository: MockProxy<EquipmentRepositoryProtocol>
+
+  let deleteEquipmentUseCase: DeleteEquipmentUseCase
+
+  beforeEach(() => {
+    equipmentRepository = mock()
+
+    deleteEquipmentUseCase = new DeleteEquipmentUseCase(equipmentRepository)
+  })
+
+  test('should delete equipment', async () => {
+    const now = Date.now()
+    const mockedResult: EquipmentDb[] = [
+      {
+            id: 'c266c9d5-4e91-4c2e-9c38-fb8710d7e896',
+            tippingNumber: '123123',
+            serialNumber: '123',
+            type: Type.Nobreak,
+            situacao: Status.ACTIVE,
+            estado: Estado.Novo,
+            model: 'Xiaomi XT',
+            description: '',
+            initialUseDate: '2022-12-12',
+            acquisitionDate: new Date('2022-12-12'),
+            invoiceNumber: '123',
+            power: '220',
+            createdAt: new Date(now),
+            updatedAt: new Date(now)
+          }
+    ]
+
+    const data: DeleteEquipmentUseCaseData = {
+      id: 'c266c9d5-4e91-4c2e-9c38-fb8710d7e896'
+    }
+
+    equipmentRepository.genericFind
+      .mockResolvedValueOnce(mockedResult)
+      .mockResolvedValueOnce(mockedResult)
+    equipmentRepository.deleteOne.mockResolvedValueOnce(true)
+
+    const result = await deleteEquipmentUseCase.execute(data)
+
+    expect(result).toHaveProperty('isSuccess', true)
+  })
+
+  test('should not delete equipment after 10 minutes of creation', async () => {
+    const now = Date.now()
+    const tenMinutes =  60 * 10 * 1000
+
+    const mockedResult: EquipmentDb[] = [
+    {
+        id: 'c266c9d5-4e91-4c2e-9c38-fb8710d7e896',
+        tippingNumber: '123123',
+        serialNumber: '123',
+        type: Type.Nobreak,
+        situacao: Status.ACTIVE,
+        estado: Estado.Novo,
+        model: 'Xiaomi XT',
+        description: '',
+        initialUseDate: '2022-12-12',
+        acquisitionDate: new Date(now - tenMinutes),
+        invoiceNumber: '123',
+        power: '220',
+        createdAt: new Date(now - tenMinutes - 1),
+        updatedAt: new Date(now - tenMinutes - 1)
+      }
+    ]
+    
+    const data: DeleteEquipmentUseCaseData = {
+      id: 'c266c9d5-4e91-4c2e-9c38-fb8710d7e896'
+    }
+
+    equipmentRepository.genericFind
+      .mockResolvedValueOnce(mockedResult)
+      .mockResolvedValueOnce(mockedResult)
+    equipmentRepository.deleteOne.mockResolvedValueOnce(true)
+
+    const result = await deleteEquipmentUseCase.execute(data)
+
+    expect(result).toHaveProperty('isSuccess', false)
+    expect(result).toHaveProperty('error')
+    expect(result.error).toBeInstanceOf(TimeLimitError)
+  })
+
+})


### PR DESCRIPTION
## Modificações
Adicionada a funcionalidade de exclusão de equipamentos com validação de 10 minutos.

## Descrição
Tentei aplicar a mesma lógica utilizada na exclusão de movimentações.

## _Issue_ relacionado
#45 Validação 10 minutos.

## Como foi testado?
Com testes automatizados que verificam a exclusão antes e depois do tempo limite.

## Tipo de modificações
- [] Nova _feature_

## Lista de controle:
- [] Meu código segue a folha de estilos implementada
- [] Meu _commits_ segue a política de commits do repo.
- [] Adicionei testes para cobrir minhas modificações.
- [] Todos os testes foram aprovados.