### PR TITLE
24 Remoção de pasta repository do coverage

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -10,5 +10,5 @@ sonar.tests=tests
 sonar.javascript.lcov.reportPaths=coverage/lcov.info
 sonar.testExecutionReportPaths=report/sonar-report.xml
 sonar.sourceEncoding=UTF-8
-sonar.coverage.exclusions=tests, dist/, node_modules, public, tsconfig.json, src/**/*.spec.ts, src/db/**/*.ts, src/*.ts, src/factories/**/*.ts, src/repository/userRepository.ts, src/presentation/protocols/*.ts
+sonar.coverage.exclusions=tests, dist/, node_modules, public, tsconfig.json, src/**/*.spec.ts, src/db/**/*.ts, src/*.ts, src/factories/**/*.ts, src/repository/**/*.ts, src/presentation/protocols/*.ts
 sonar.cpd.exclusions=src/**/*.test.ts, tests


### PR DESCRIPTION
## Modificações
 Remoção temporária da pasta repository dos arquivos considerados no coverage do sonar.