### PR TITLE
81 - Adicionar Filtros de Movimentação

### DIFF
--- a/src/repository/movementRepository.ts
+++ b/src/repository/movementRepository.ts
@@ -109,6 +109,14 @@ export class MovementRepository implements MovementRepositoryProtocol {
 
     const { resultQuantity, page, ...rest } = query
 
+    let formattedHigherDate = new Date(higherDate)
+
+    if (typeof higherDate === 'undefined' && typeof lowerDate !== 'undefined') {
+      formattedHigherDate = new Date()
+    } else if (typeof higherDate !== 'undefined') {
+      formattedHigherDate.setDate(formattedHigherDate.getDate() + 1)
+    }
+
     const defaultConditions = {
       id,
       userId,
@@ -116,7 +124,7 @@ export class MovementRepository implements MovementRepositoryProtocol {
       equipments: equipmentId ? { id: equipmentId } : undefined,
       destination: destination ? { id: destination } : undefined,
       date: lowerDate
-        ? And(MoreThanOrEqual(lowerDate), LessThanOrEqual(higherDate))
+        ? And(MoreThanOrEqual(lowerDate), LessThanOrEqual(formattedHigherDate))
         : undefined
     }
 

--- a/src/repository/movementRepository.ts
+++ b/src/repository/movementRepository.ts
@@ -1,11 +1,4 @@
-import {
-  MoreThanOrEqual,
-  LessThanOrEqual,
-  And,
-  ILike,
-  Not,
-  IsNull
-} from 'typeorm'
+import { MoreThanOrEqual, LessThanOrEqual, And, ILike } from 'typeorm'
 import { dataSource } from '../db/config'
 import { Movement as MovementEntity } from '../db/entities/movement'
 import { Equipment as EquipmentEntity } from '../db/entities/equipment'
@@ -127,24 +120,27 @@ export class MovementRepository implements MovementRepositoryProtocol {
         : undefined
     }
 
-    const whereConditions = [
-      {
-        inChargeName: ILike(`%${searchTerm}%`),
-        ...defaultConditions
-      },
-      {
-        inChargeRole: ILike(`%${searchTerm}%`),
-        ...defaultConditions
-      },
-      {
-        chiefName: ILike(`%${searchTerm}%`),
-        ...defaultConditions
-      },
-      {
-        chiefRole: ILike(`%${searchTerm}%`),
-        ...defaultConditions
-      }
-    ]
+    const whereConditions =
+      typeof searchTerm !== 'undefined'
+        ? [
+            {
+              inChargeName: ILike(`%${searchTerm}%`),
+              ...defaultConditions
+            },
+            {
+              inChargeRole: ILike(`%${searchTerm}%`),
+              ...defaultConditions
+            },
+            {
+              chiefName: ILike(`%${searchTerm}%`),
+              ...defaultConditions
+            },
+            {
+              chiefRole: ILike(`%${searchTerm}%`),
+              ...defaultConditions
+            }
+          ]
+        : defaultConditions
 
     const allFieldsUndefined = Object.values(rest).every(
       (value) => typeof value === 'undefined'

--- a/src/repository/movementRepository.ts
+++ b/src/repository/movementRepository.ts
@@ -102,6 +102,7 @@ export class MovementRepository implements MovementRepositoryProtocol {
         'equipments.brand',
         'equipments.unit',
         'destination'
+
       ],
       order: {
         date: 'DESC'
@@ -110,18 +111,24 @@ export class MovementRepository implements MovementRepositoryProtocol {
         id: query.id,
         userId: query.userId,
         type: query.type,
+        inChargeName: query.inChargeName,
         equipments: query.equipmentId
           ? {
               id: query.equipmentId
             }
           : undefined,
-        date: query.lowerDate
+          destination: query.destination
+          ? {
+              id: query.destination
+            }
+          : undefined,
+          date:query.lowerDate
           ? And(
-              MoreThanOrEqual(query.lowerDate),
-              LessThanOrEqual(query.higherDate)
-            )
+             MoreThanOrEqual(query.lowerDate),
+             LessThanOrEqual(query.higherDate)
+           )
           : undefined
-      },
+       },
       take: query.resultQuantity,
       skip: query.page * query.resultQuantity
     })

--- a/src/repository/protocol/movementRepositoryProtocol.ts
+++ b/src/repository/protocol/movementRepositoryProtocol.ts
@@ -6,13 +6,14 @@ export type Query = {
   id?: string
   destination?: string
   userId?: string
-  inChargeName?:string
+  inChargeName?: string
   equipmentId?: string
   type?: number
   lowerDate?: Date
   higherDate?: Date
   page: number
   resultQuantity: number
+  searchTerm?: string
 }
 
 export interface MovementRepositoryProtocol {

--- a/src/repository/protocol/movementRepositoryProtocol.ts
+++ b/src/repository/protocol/movementRepositoryProtocol.ts
@@ -1,9 +1,12 @@
 import { Movement } from '../../domain/entities/movement'
 import { Status as EquipmentStatus } from '../../domain/entities/equipamentEnum/status'
+import { Unit } from '../../domain/entities/unit'
 
 export type Query = {
   id?: string
+  destination?: string
   userId?: string
+  inChargeName?:string
   equipmentId?: string
   type?: number
   lowerDate?: Date

--- a/src/useCases/findMovements/findMovementsUseCase.ts
+++ b/src/useCases/findMovements/findMovementsUseCase.ts
@@ -37,13 +37,12 @@ export class FindMovementsUseCase
   ) {}
 
   private areDatesInvalid(data: FindMovementsUseCaseData): boolean {
-    if (data.lowerDate || data.higherDate)
-      if (
-        !(data.lowerDate && data.higherDate) ||
-        data.higherDate < data.lowerDate
-      )
+    if (data.lowerDate) {
+      if (data.higherDate && data.higherDate < data.lowerDate) {
         return true
-    return false
+      }
+      return false
+    }
   }
 
   async execute(

--- a/src/useCases/findMovements/findMovementsUseCase.ts
+++ b/src/useCases/findMovements/findMovementsUseCase.ts
@@ -19,6 +19,7 @@ export type FindMovementsUseCaseData = {
   higherDate?: Date
   page?: number
   resultquantity?: number
+  searchTerm?: string
 }
 
 export class InvalidDateError extends Error {
@@ -66,6 +67,7 @@ export class FindMovementsUseCase
       inChargeName: data.inChargeName,
       lowerDate: data.lowerDate,
       higherDate: data.higherDate,
+      searchTerm: data.searchTerm,
       page,
       resultQuantity
     }

--- a/src/useCases/findMovements/findMovementsUseCase.ts
+++ b/src/useCases/findMovements/findMovementsUseCase.ts
@@ -6,14 +6,17 @@ import {
   MovementRepositoryProtocol,
   Query
 } from '../../repository/protocol/movementRepositoryProtocol'
+import { Unit } from '../../domain/entities/unit'
 
 export type FindMovementsUseCaseData = {
   id?: string
+  destinationId?: string
   userid?: string
   equipmentid?: string
+  inChargeName?: string
   type?: number
-  lowerdate?: Date
-  higherdate?: Date
+  lowerDate?: Date
+  higherDate?: Date
   page?: number
   resultquantity?: number
 }
@@ -33,10 +36,10 @@ export class FindMovementsUseCase
   ) {}
 
   private areDatesInvalid(data: FindMovementsUseCaseData): boolean {
-    if (data.lowerdate || data.higherdate)
+    if (data.lowerDate || data.higherDate)
       if (
-        !(data.lowerdate && data.higherdate) ||
-        data.higherdate < data.lowerdate
+        !(data.lowerDate && data.higherDate) ||
+        data.higherDate < data.lowerDate
       )
         return true
     return false
@@ -56,11 +59,13 @@ export class FindMovementsUseCase
 
     const query: Query = {
       id: data.id,
+      destination: data.destinationId,
       userId: data.userid,
       equipmentId: data.equipmentid,
       type: data.type,
-      lowerDate: data.lowerdate,
-      higherDate: data.higherdate,
+      inChargeName: data.inChargeName,
+      lowerDate: data.lowerDate,
+      higherDate: data.higherDate,
       page,
       resultQuantity
     }

--- a/tests/findMovementsController.spec.ts
+++ b/tests/findMovementsController.spec.ts
@@ -90,8 +90,8 @@ describe('Create movement controller', () => {
   test('should get a bad request response', async () => {
     const query: FindMovementsUseCaseData = {
       type: 1,
-      lowerdate: new Date('2023-01-10T07:16:32.276Z'),
-      higherdate: new Date('2023-01-10T07:14:54.078Z')
+      lowerDate: new Date('2023-01-10T07:16:32.276Z'),
+      higherDate: new Date('2023-01-10T07:14:54.078Z')
     }
 
     findMovementsUseCase.execute.mockResolvedValue({
@@ -109,8 +109,8 @@ describe('Create movement controller', () => {
   test('should return server error request response', async () => {
     const query: FindMovementsUseCaseData = {
       type: 1,
-      lowerdate: new Date('2023-01-10T07:16:32.276Z'),
-      higherdate: new Date('2023-01-10T07:14:54.078Z')
+      lowerDate: new Date('2023-01-10T07:16:32.276Z'),
+      higherDate: new Date('2023-01-10T07:14:54.078Z')
     }
 
     findMovementsUseCase.execute.mockResolvedValue({

--- a/tests/findMovementsUseCase.spec.ts
+++ b/tests/findMovementsUseCase.spec.ts
@@ -190,8 +190,8 @@ describe('Find movements use case', () => {
 
     const query: FindMovementsUseCaseData = {
       type: 1,
-      lowerdate: new Date('2023-01-10T07:16:32.276Z'),
-      higherdate: new Date('2023-01-10T07:14:54.078Z')
+      lowerDate: new Date('2023-01-10T07:16:32.276Z'),
+      higherDate: new Date('2023-01-10T07:14:54.078Z')
     }
 
     movementRepository.genericFind.mockResolvedValueOnce(mockedResult)
@@ -236,7 +236,7 @@ describe('Find movements use case', () => {
 
     const query: FindMovementsUseCaseData = {
       type: 1,
-      lowerdate: new Date('2023-01-10T07:16:32.276Z')
+      lowerDate: new Date('2023-01-10T07:16:32.276Z')
     }
 
     movementRepository.genericFind.mockResolvedValueOnce(mockedResult)

--- a/tests/findMovementsUseCase.spec.ts
+++ b/tests/findMovementsUseCase.spec.ts
@@ -204,7 +204,7 @@ describe('Find movements use case', () => {
     expect(result.error).toBeInstanceOf(InvalidDateError)
   })
 
-  test('should not find movements with by date when higher date is missing', async () => {
+  test('should find movements with by date when higher date is missing', async () => {
     const mockedResult: Movement[] = [
       {
         id: '130265af-6afd-494d-b025-e657db264e56',
@@ -243,9 +243,8 @@ describe('Find movements use case', () => {
 
     const result = await findMovementsUseCase.execute(query)
 
-    expect(result).toHaveProperty('isSuccess', false)
-    expect(result).not.toHaveProperty('data')
-    expect(result).toHaveProperty('error')
-    expect(result.error).toBeInstanceOf(InvalidDateError)
+    expect(result).toHaveProperty('isSuccess', true)
+    expect(result).toHaveProperty('data')
+    expect(result).not.toHaveProperty('error')
   })
 })


### PR DESCRIPTION
## Modificações
 Adição de filtros para listagem de movimentações.
## Descrição
  - Adição do parâmetro de searchTerm na query de listar movimentações.
  - Ajuste nos testes que estavam quebrando.
## _Issue_ relacionado
 81
## Como foi testado?
   - Foi ajustado teste que já existia para listagem de movimentações.

## Lista de controle:
- [x] Meu código segue a folha de estilos implementada
- [x] Meu _commits_ segue a política de commits do repo.
- [x] Adicionei testes para cobrir minhas modificações.
