### PR TITLE
84 filtro de busca equipamentos

### DIFF
--- a/src/domain/entities/equipamentEnum/status.ts
+++ b/src/domain/entities/equipamentEnum/status.ts
@@ -4,5 +4,6 @@ export enum Status {
   ACTIVE_LOAN = 'Ativo Empréstimo',
   DOWNGRADED = 'Baixado',
   MAINTENANCE = 'Manutenção',
-  TECHNICAL_RESERVE = 'Reserva Técnica'
+  TECHNICAL_RESERVE = 'Reserva Técnica',
+  STORAGE = 'Estoque'
 }

--- a/src/presentation/controller/getEquipmentController.ts
+++ b/src/presentation/controller/getEquipmentController.ts
@@ -1,3 +1,4 @@
+import { Equipment } from '../../domain/entities/equipment'
 import {
   GetEquipmentInput,
   GetEquipmentUseCase
@@ -7,7 +8,7 @@ import { HttpResponse, ok, serverError } from '../helpers'
 import { Controller } from '../protocols/controller'
 
 type HttpRequest = GetEquipmentInput
-type Model = Error | any
+type Model = Error | Equipment[]
 
 export class GetEquipmentController extends Controller {
   constructor(private getEquipmentUseCase: GetEquipmentUseCase) {

--- a/src/repository/equipamentRepository.ts
+++ b/src/repository/equipamentRepository.ts
@@ -54,11 +54,12 @@ export class EquipmentRepository implements EquipmentRepositoryProtocol {
       },
       where: {
         type: query.type,
-        unit: query.location
+        unit: query.unit
         ? {
-            id: query.location
-          }
+          id: query.unit
+        }
         : undefined,
+        situacao: query.situation,
         brand: query.brand
         ? {
             id: query.brand

--- a/src/repository/equipamentRepository.ts
+++ b/src/repository/equipamentRepository.ts
@@ -1,6 +1,7 @@
+import { MoreThanOrEqual } from 'typeorm'
 import { dataSource } from '../db/config'
 import { Equipment } from '../db/entities/equipment'
-import { EquipmentRepositoryProtocol } from './protocol/equipmentRepositoryProtocol'
+import { EquipmentRepositoryProtocol, Query } from './protocol/equipmentRepositoryProtocol'
 
 export class EquipmentRepository implements EquipmentRepositoryProtocol {
   private readonly equipmentRepository
@@ -32,7 +33,7 @@ export class EquipmentRepository implements EquipmentRepositoryProtocol {
     return equipment
   }
 
-  async genericFind(query: any): Promise<Equipment[]> {
+  async genericFind(query: Query): Promise<Equipment[]> {
     console.log('Query repository: ', query)
     
     const take = query.take
@@ -46,11 +47,27 @@ export class EquipmentRepository implements EquipmentRepositoryProtocol {
       skip: skip,
       relations: {
         brand: true,
-        acquisition: true,
         unit: true
       },
+      order: {
+        updatedAt: 'DESC'
+      },
       where: {
-        ...query
+        type: query.type,
+        unit: query.location
+        ? {
+            id: query.location
+          }
+        : undefined,
+        brand: query.brand
+        ? {
+            id: query.brand
+          }
+        : undefined,
+        updatedAt: query.updatedAt
+        ? MoreThanOrEqual(query.updatedAt)
+        : undefined,
+        model: query.model
       }
     })
     return equipments

--- a/src/repository/equipamentRepository.ts
+++ b/src/repository/equipamentRepository.ts
@@ -1,7 +1,8 @@
-import { MoreThanOrEqual } from 'typeorm'
+import { MoreThanOrEqual, ILike } from 'typeorm'
 import { dataSource } from '../db/config'
 import { Equipment } from '../db/entities/equipment'
 import { EquipmentRepositoryProtocol, Query } from './protocol/equipmentRepositoryProtocol'
+
 
 export class EquipmentRepository implements EquipmentRepositoryProtocol {
   private readonly equipmentRepository
@@ -68,9 +69,11 @@ export class EquipmentRepository implements EquipmentRepositoryProtocol {
         updatedAt: query.updatedAt
         ? MoreThanOrEqual(query.updatedAt)
         : undefined,
-        model: query.model
-      }
-    })
+        model: query.model,
+        tippingNumber: query.searchId? ILike( `%${query.searchId}%` ): undefined, 
+        serialNumber: query.searchId? ILike( `%${query.searchId}%` ):undefined,
+      },
+    });
     return equipments
   }
 

--- a/src/repository/protocol/equipmentRepositoryProtocol.ts
+++ b/src/repository/protocol/equipmentRepositoryProtocol.ts
@@ -7,10 +7,10 @@ export type Query = {
   situation?: string
   updatedAt?: Date
   brand?: string
-  model?: string
+  search?: string
+  model?: string 
   take?: number
   skip?: number
-  searchId?: string
 }
 
 export interface EquipmentRepositoryProtocol {

--- a/src/repository/protocol/equipmentRepositoryProtocol.ts
+++ b/src/repository/protocol/equipmentRepositoryProtocol.ts
@@ -1,10 +1,11 @@
 import { Equipment } from '../../db/entities/equipment'
+import { Status } from '../../domain/entities/equipamentEnum/status'
 
 export type Query = {
   type?: string
-  location?: string
+  unit?: string
   situation?: string
-  updatedAt?: string
+  updatedAt?: Date
   brand?: string
   model?: string
   take?: number

--- a/src/repository/protocol/equipmentRepositoryProtocol.ts
+++ b/src/repository/protocol/equipmentRepositoryProtocol.ts
@@ -10,6 +10,7 @@ export type Query = {
   model?: string
   take?: number
   skip?: number
+  searchId?: string
 }
 
 export interface EquipmentRepositoryProtocol {

--- a/src/repository/protocol/equipmentRepositoryProtocol.ts
+++ b/src/repository/protocol/equipmentRepositoryProtocol.ts
@@ -1,5 +1,16 @@
 import { Equipment } from '../../db/entities/equipment'
 
+export type Query = {
+  type?: string
+  location?: string
+  situation?: string
+  updatedAt?: string
+  brand?: string
+  model?: string
+  take?: number
+  skip?: number
+}
+
 export interface EquipmentRepositoryProtocol {
   create(equipment: Equipment): Promise<Equipment>
   updateOne(equipmentData: any): Promise<boolean>


### PR DESCRIPTION
## Modificações
 Adição de filtros para listar equipamentos
## Descrição
  - Adição do termo para filtragem por campo de busca
  - Filtragem de equipamentos por tipo, situação, posto de trabalho, data da última atualização, seria, tombamento, modelo
## _Issue_ relacionado
 84
## Como foi testado?
- Ajuste de testes já existentes.

## Lista de controle:
- [x] Meu código segue a folha de estilos implementada
- [x] Meu _commits_ segue a política de commits do repo.
- [x] Adicionei testes para cobrir minhas modificações.
