### PR TITLE
102 listagem ordem de serviço

### DIFF
--- a/src/repository/order-service/list-order-service.ts
+++ b/src/repository/order-service/list-order-service.ts
@@ -15,7 +15,15 @@ export class ListOrderServiceRepository
   ): Promise<OrderService[] | undefined> {
     delete query.userId
 
+    const take = query.take
+    const skip = query.skip
+
+    delete query.take
+    delete query.skip
+
     const os = await this.orderServiceRepository.find({
+      take: take,
+      skip: skip,
       relations: ['equipment'],
       where: {
         ...query

--- a/src/repository/order-service/list-order-service.ts
+++ b/src/repository/order-service/list-order-service.ts
@@ -24,7 +24,7 @@ export class ListOrderServiceRepository
     const os = await this.orderServiceRepository.find({
       take: take,
       skip: skip,
-      relations: ['equipment'],
+      relations: ['equipment', 'equipment.brand', 'equipment.unit'],
       where: {
         ...query
       }

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -34,7 +34,7 @@ routes.delete(
 routes.get('/getAllUnits', adapt(makeFindAllUnitsController()))
 routes.get('/getAllBrands', adapt(makeFindAllBrandsController()))
 routes.get('/getAllAcquisitions', adapt(makeFindAllAcquisitionsController()))
-routes.get('/listOrderSerice', adapt(makeFindOrderServiceController()))
+routes.get('/listOrderService', adapt(makeFindOrderServiceController()))
 routes.get('/listOne', adapt(makeFindOneEquipmentController()))
 routes.put('/updateOrderService', adapt(makeUpdateOrderController()))
 routes.post('/createMovement', adapt(makeCreateMovementController()))

--- a/src/useCases/find-order-service/find-order-service.ts
+++ b/src/useCases/find-order-service/find-order-service.ts
@@ -21,6 +21,8 @@ export type FindOrderServiceUseCaseData = {
   serialNumber: string
   type: string
   situacao: string
+  take?: number
+  skip?: number
 }
 
 export class FindOrderService
@@ -40,7 +42,9 @@ export class FindOrderService
         serialNumber: query.serialNumber,
         type: query.type,
         situacao: query.situacao
-      }
+      },
+      take: query.take,
+      skip: query.skip
     }
     const ordersServices = await this.osReposiory.findOrderServiceGeneric(
       queryFormatted


### PR DESCRIPTION
## Modificações
Adiciona paginação para a listagem das ordens de serviço
Corrige ortografia da rota de listagem
Adiciona mais infos no retorno na listagem de ordem de serviço

## _Issue_ relacionado
102

## Motivação e Contexto
Para que seja possível a visualização de 10 ordens de serviço por página na interface

## Como foi testado?
Com os testes já existentes

## Tipo de modificações
- [] _ ​​correção de bug_
- [x] Nova _feature_

## Lista de controle:
- [x] Meu código segue a folha de estilos implementada
- [x] Meu _commits_ segue a política de commits do repo.
- [] Minhas modificações requerem modificações na documentação atual.
- [] Atualizei a Documentação
- [] Adicionei testes para cobrir minhas modificações.
- [x] Todos os testes foram aprovados.